### PR TITLE
feat: convert repository to ESM

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 /**
  * @param {import('probot').Probot} app
  */
-module.exports = (app) => {
+export default (app) => {
   app.log.info("Yay! The app was loaded!");
 
   app.on("issues.opened", async (context) => {

--- a/netlify/functions/webhooks.js
+++ b/netlify/functions/webhooks.js
@@ -1,5 +1,5 @@
-const { createProbot } = require("probot");
-const app = require("../../app");
+import { createProbot } from "probot";
+import app from "../../app.js";
 
 const probot = createProbot();
 const loadingApp = probot.load(app);
@@ -10,7 +10,7 @@ const loadingApp = probot.load(app);
  * @param {import("@netlify/functions").HandlerEvent} event
  * @param {import("@netlify/functions").HandlerContext} context
  */
-exports.handler = async function (event, context) {
+export const handler = async function (event, context) {
   try {
     await loadingApp;
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Probot & Netlify Functions example",
   "main": "app.js",
+  "type": "module",
   "scripts": {
     "start": "probot run ./app.js",
     "test": "node test.js"

--- a/test.js
+++ b/test.js
@@ -1,12 +1,12 @@
-const { suite } = require("uvu");
-const assert = require("uvu/assert");
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
 
-const nock = require("nock");
+import nock from "nock";
 nock.disableNetConnect();
 
-const { Probot, ProbotOctokit } = require("probot");
+import { Probot, ProbotOctokit } from "probot";
 
-const app = require("./app");
+import app from "./app.js";
 
 /** @type {import('probot').Probot */
 let probot;


### PR DESCRIPTION
BREAKING CHANGE: Transition to ESM only
Converts the repository to use ESM syntax, enabling module support.

- Adds `"type": "module"` to `package.json` to specify ESM support.
- Updates `app.js` and `netlify/functions/webhooks.js` by replacing `require` statements with `import` statements and changing `module.exports` to `export default`.
- Modifies `test.js` to use ESM import/export syntax, including updating `require` statements to `import` and changing `module.exports` to `export default` for the test suite.